### PR TITLE
fix upperbound

### DIFF
--- a/main.go
+++ b/main.go
@@ -56,7 +56,7 @@ const (
 	maxAllowed                       = "max"
 	targetRecommendation             = "target"
 	lowerBoundRecommendation         = "lowerBound"
-	upperBoundRecommendation         = "lowerBound"
+	upperBoundRecommendation         = "upperBound"
 	uncappedTargetRecommendation     = "uncappedTarget"
 	vpaNamespace                     = "vpa"
 	subsystemMetadata                = "metadata"


### PR DESCRIPTION
**What this PR does / why we need it**:
The upperBound metrics were not exposed because the upperBound variable had the value `lowerBound`. Upper bound metrics are now exposed.
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy
- target_group:   user|operator
-->
```improvement operator
Upperbound metrics are now properly exposed.
```
