### PR TITLE
Use default port allocation for metrics

### DIFF
--- a/main.go
+++ b/main.go
@@ -434,5 +434,5 @@ func init() {
 	flag.StringVar(&kubeconfig, "kubeconfig", "", "Path to a kubeconfig. Only required if out-of-cluster.")
 	flag.StringVar(&masterURL, "master", "", "The address of the Kubernetes API server. Overrides any value in kubeconfig. Only required if out-of-cluster.")
 	flag.StringVar(&namespace, "namespace", "", "Namespace in which the VPA resources have to be listened to.")
-	flag.IntVar(&port, "port", 80, "The port on which prometheus metrics are exposed.")
+	flag.IntVar(&port, "port", 9570, "The port on which prometheus metrics are exposed.")
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
The `vpa-exporter` is now listed as an exporter on the [prometheus exporter wiki](https://github.com/prometheus/prometheus/wiki/Default-port-allocations). This PR changes the default port value to the value in the wiki.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy
- target_group:   user|operator
-->
```improvement operator
Change default port to `9570`
```
