### PR TITLE
Build image from scratch and skip protecode scans

### DIFF
--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -40,3 +40,14 @@ vpa-exporter:
         release:
           nextversion: 'bump_minor'
         component_descriptor: ~
+
+  release:
+    traits:
+      publish:
+        container_images:
+          vpa-exporter:
+            resource_labels:
+              - name: 'cloud.gardener.cnudie/dso/scanning-hints/binary/v1'
+                value:
+                  policy: 'skip' # this will tell our scanning-gear that the image should not be scanned using protecode
+                  comment: 'payload is a statically-linked elf-binary'

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -12,9 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM alpine:3.10.3
-
-RUN apk add --update bash curl
+FROM scratch
 
 COPY ./bin/linux-amd64/vpa-exporter /usr/local/bin/vpa-exporter
 WORKDIR /


### PR DESCRIPTION
**What this PR does / why we need it**:
Build image from scratch and skip protecode scans

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
cc @AndreasBurger @ccwienk Can you please check if the pipeline definition change is fine for labelling the container image to skip the statically linked ELF binary?

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy
- target_group:   user|operator
-->
```improvement operator
Build image from scratch and skip protecode scans
```
