### PR TITLE
Build Multi-Arch Images 📦

### DIFF
--- a/.ci/build
+++ b/.ci/build
@@ -58,19 +58,7 @@ VERSION_FILE="$(readlink  -f "${SOURCE_PATH}/VERSION")"
 VERSION="$(cat "${VERSION_FILE}")"
 GIT_SHA=$(git rev-parse --short HEAD || echo "GitNotFound")
 
-# If no LOCAL_BUILD environment variable is set, we configure the `go build` command
-# to build for linux OS, amd64 architectures and without CGO enablement.
-if [[ -z "$LOCAL_BUILD" ]]; then
-  CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build \
-    -a \
-    -v \
-    -o ${BINARY_PATH}/linux-amd64/vpa-exporter \
-    main.go
-
-# If the LOCAL_BUILD environment variable is set, we simply run `go build`.
-else
-  go build \
-    -v \
-    -o ${BINARY_PATH}/vpa-exporter \
-    main.go
-fi
+CGO_ENABLED=0 GO111MODULE=off go build \
+  -v \
+  -o ${BINARY_PATH}/vpa-exporter \
+  main.go

--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -8,6 +8,10 @@ vpa-exporter:
           'inject-commit-hash'
         inject_effective_version: true
       publish:
+        oci-builder: docker-buildx
+        platforms:
+        - linux/amd64
+        - linux/arm64
         dockerimages:
           vpa-exporter:
             registry: 'gcr-readwrite'

--- a/Makefile
+++ b/Makefile
@@ -27,13 +27,8 @@ revendor:
 build: 
 	@.ci/build
 
-.PHONY: build-local
-build-local:
-	@env LOCAL_BUILD=1 .ci/build
-
 .PHONY: docker-image
 docker-image: 
-	@if [[ ! -f $(BIN_DIR)/linux-amd64/vpa-exporter ]]; then echo "No binary found. Please run 'make build'"; false; fi
 	@docker build -t $(IMAGE_REPOSITORY):$(IMAGE_TAG) -f $(BUILD_DIR)/Dockerfile --rm .
 
 .PHONY: docker-push

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -12,10 +12,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+FROM golang:1.18 as builder
+WORKDIR /go/src/github.com/gardener/vpa-exporter
+COPY . .
+
+RUN make build
+
 FROM alpine:3.10.3
 
 RUN apk add --update bash curl
 
-COPY ./bin/linux-amd64/vpa-exporter /usr/local/bin/vpa-exporter
+COPY --from=builder /go/src/github.com/gardener/vpa-exporter/bin/vpa-exporter /usr/local/bin/vpa-exporter
 WORKDIR /
 ENTRYPOINT ["/usr/local/bin/vpa-exporter"]


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR lets the CI pipeline build multi-arch images with support for `linux/amd64` and `linux/arm64`.

**Which issue(s) this PR fixes**:
Fixes parts of https://github.com/gardener/gardener/issues/6258

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy
- target_group:   user|operator
-->
```improvement operator
Published docker images for VPA-Exporter are now multi-arch ready. They support `linux/amd64` and `linux/arm64`.
```
