### PR TITLE
Bump builder image to golang 1.18.5

### DIFF
--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -24,9 +24,9 @@ vpa-exporter:
                 build: ~
     steps:
       check:
-        image: 'golang:1.12.0'
+        image: 'golang:1.18.5'
       build:
-        image: 'golang:1.12.0'
+        image: 'golang:1.18.5'
         output_dir: 'binary'
 
   jobs:


### PR DESCRIPTION
**What this PR does / why we need it**:
Bumps builder image from golang 1.12 to 1.18.5 to enable subsequent transition to golang 1.18.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy
- target_group:   user|operator
-->
```improvement operator
NONE
```
