### PR TITLE
Change base image from alpine to distroless

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -18,10 +18,8 @@ COPY . .
 
 RUN make build
 
-FROM alpine:3.10.3
+FROM gcr.io/distroless/static-debian11:nonroot
+COPY --from=builder /go/src/github.com/gardener/vpa-exporter/bin/vpa-exporter /vpa-exporter
 
-RUN apk add --update bash curl
-
-COPY --from=builder /go/src/github.com/gardener/vpa-exporter/bin/vpa-exporter /usr/local/bin/vpa-exporter
 WORKDIR /
-ENTRYPOINT ["/usr/local/bin/vpa-exporter"]
+ENTRYPOINT ["/vpa-exporter"]


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR changes the base image for `vpa-exporter` container from `alpine` to [distroless](https://github.com/GoogleContainerTools/distroless). The process will now use a non root user for its execution. This will reduce the attack surface of the image.

This PR supersedes #19

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy
- target_group:   user|operator
-->
```noteworthy operator
The `vpa-exporter` container now uses `distroless` instead of `alpine` as a base image.
```
