### PR TITLE
Bump golang to 1.18.7

### DIFF
--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -24,9 +24,9 @@ vpa-exporter:
                 build: ~
     steps:
       check:
-        image: 'golang:1.18.5'
+        image: 'golang:1.18.7'
       build:
-        image: 'golang:1.18.5'
+        image: 'golang:1.18.7'
         output_dir: 'binary'
 
   jobs:

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.18.5 as builder
+FROM golang:1.18.7 as builder
 WORKDIR /go/src/github.com/gardener/vpa-exporter
 COPY . .
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Bump golang to 1.18.7

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy
- target_group:   user|operator
-->
```improvement operator
The underlying golang library was updated to version 1.18.7
```
